### PR TITLE
Add Exception-Message to Slack-Payload

### DIFF
--- a/src/Slack/ExceptionOccurredPayload.php
+++ b/src/Slack/ExceptionOccurredPayload.php
@@ -19,7 +19,7 @@ class ExceptionOccurredPayload
             "attachments" => [
                 [
                     "text"  => "*Environment:* "   . config('app.env') . " " . config('laravel_alert_notifications.slack.subject')
-                       . "\n" . "Request Url: "    . "http://localhost"
+                       . "\n" . "Exception Message: " . $this->exception->getMessage()
                        . "\n" . "Exception: "      . get_class($this->exception)
                        . "\n" . "Exception Code: " . $this->exception->getCode()
                        . "\n" . "In File: *"       . $this->exception->getFile() . '* on line ' . $this->exception->getLine()


### PR DESCRIPTION
Sometime is it clearer if you get the message of the exception. The fix URL http://localhost is unnecessary.
