### PR TITLE
Fix view name

### DIFF
--- a/src/Mail/ExceptionOccurredMail.php
+++ b/src/Mail/ExceptionOccurredMail.php
@@ -14,7 +14,7 @@ class ExceptionOccurredMail extends Mailable
     public $exception;
     public $exceptionContext;
 
-    public $view = 'vendor.laravel_alert_notifications.mail';
+    public $view = 'laravel_alert_notifications::mail';
 
     protected $notificationLevel;
 


### PR DESCRIPTION
View name should user the package prefix so it can be loaded directly from the package without having to publish into the project itself if the consumer doesn't want to.

https://laravel.com/docs/5.0/packages#views