### PR TITLE
Use htmlspecialchars ENT_SUBSTITUTE

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "kevincobain2000/laravel-alert-notifications",
     "description": "Alert notifications of exceptions from your laravel application",
     "license": "MIT",
-    "version": "4.1",
+    "version": "4.2",
     "keywords": ["email", "exception", "laravel", "laravel-5-package", "exception-handling", "debugging"],
     "authors": [
         {

--- a/src/Mail/ExceptionOccurredMail.php
+++ b/src/Mail/ExceptionOccurredMail.php
@@ -6,6 +6,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Symfony\Component\ErrorHandler\Exception\FlattenException;
 
 class ExceptionOccurredMail extends Mailable
 {
@@ -37,6 +38,7 @@ class ExceptionOccurredMail extends Mailable
         $data = [
             'exception' => $this->exception,
             'context'   => $this->exceptionContext,
+            'flattenException' => FlattenException::create($this->exception)
         ];
 
         return $this->subject($subject)->from($from)->to($to)->with($data);

--- a/src/Mail/ExceptionOccurredMail.php
+++ b/src/Mail/ExceptionOccurredMail.php
@@ -6,7 +6,6 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Symfony\Component\ErrorHandler\Exception\FlattenException;
 
 class ExceptionOccurredMail extends Mailable
 {
@@ -37,8 +36,7 @@ class ExceptionOccurredMail extends Mailable
 
         $data = [
             'exception' => $this->exception,
-            'context'   => $this->exceptionContext,
-            'flattenException' => FlattenException::create($this->exception)
+            'context'   => $this->exceptionContext
         ];
 
         return $this->subject($subject)->from($from)->to($to)->with($data);

--- a/src/views/mail.blade.php
+++ b/src/views/mail.blade.php
@@ -51,7 +51,7 @@
                                     <strong>Exception Message:</strong>
                                 </td>
                                 <td>
-                                    {{ $exception->getMessage() }}
+                                    {!! htmlspecialchars($exception->getMessage(), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') !!}
                                 </td>
                             </tr>
                             <tr>
@@ -88,7 +88,7 @@
                             </tr>
                             <tr>
                                 <td align="left" style="text-align: left;">
-                                    <pre style="white-space: pre-wrap;">{{$exception->getTraceAsString()}}</pre>
+                                    <pre style="white-space: pre-wrap;">{!! htmlspecialchars($flattenException->getAsString(), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') !!}</pre>
                                 </td>
                             </tr>
                         </table>

--- a/src/views/mail.blade.php
+++ b/src/views/mail.blade.php
@@ -88,7 +88,7 @@
                             </tr>
                             <tr>
                                 <td align="left" style="text-align: left;">
-                                    <pre style="white-space: pre-wrap;">{!! htmlspecialchars($flattenException->getAsString(), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') !!}</pre>
+                                    <pre style="white-space: pre-wrap;">{!! htmlspecialchars($exception->getTraceAsString(), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') !!}</pre>
                                 </td>
                             </tr>
                         </table>


### PR DESCRIPTION
What are added
1. Use htmlspecialchars `ENT_SUBSTITUTE` to replace invalid utf-8 string instead of returning empty string.
2. Use FlattenException to print all nested stack traces

Why
1. Double curly `{{` uses default htmlspecialchars flag which will convert invalid utf-8 string into empty string.
There are some cases where error messages contains invalid utf-8 espcially handling file contents from different encoding.
Without `ENT_SUBSTITUTE` we will get empty in message section.
Same applied to stack trace
2. Currently stack trace only output last stack trace. It is easier to debug if nested stack traces are outputted. We could utilize `FlattenException::getAsString()` provided by Symfony.
Cons: Content could be huge if stack trace is long.

Reference:
1. https://www.php.net/manual/en/function.htmlspecialchars.php
2. https://github.com/laravel/framework/blob/6.x/src/Illuminate/Support/helpers.php#L245
3. https://github.com/symfony/symfony/blob/master/src/Symfony/Component/ErrorHandler/Exception/FlattenException.php#L370