### PR TITLE
Simplify on action in github action

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,10 +1,4 @@
-on:
-  pull_request:
-  push:
-    branches:
-      - **
-    tags:
-      - **
+on: [fork, pull_request, push]
 
 name: Continuous Integration
 


### PR DESCRIPTION
Just run based on the action. No need to specify branches/tags if we're wanting to use all branches/tags.