### PR TITLE
Remove deprecated set-output from actions

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Determine composer cache directory
         id: determine-composer-cache-directory
-        run: echo "::set-output name=directory::$(composer config cache-dir)"
+        run: echo "directory=$(composer config cache-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies installed with composer
         uses: actions/cache@v4
@@ -63,7 +63,7 @@ jobs:
 
       - name: Determine composer cache directory
         id: determine-composer-cache-directory
-        run: echo "::set-output name=directory::$(composer config cache-dir)"
+        run: echo "directory=$(composer config cache-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies installed with composer
         uses: actions/cache@v4
@@ -101,7 +101,7 @@ jobs:
 
       - name: Determine composer cache directory
         id: determine-composer-cache-directory
-        run: echo "::set-output name=directory::$(composer config cache-dir)"
+        run: echo "directory=$(composer config cache-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies installed with composer
         uses: actions/cache@v4


### PR DESCRIPTION
Remove deprecated actions syntax.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/